### PR TITLE
fix: Timegate Error {numId}: The answer is no. Just... no.

### DIFF
--- a/services/timegate/src/services/dialogue-hub.service.ts
+++ b/services/timegate/src/services/dialogue-hub.service.ts
@@ -14,7 +14,7 @@ export const postOpenRouterMessage = async (
                 message,
                 ...contextId ? { contextId } : {}
             },
-            { ...errorRate ? { params: { errorRate } } : {} }
+            { ...errorRate != null ? { params: { errorRate } } : {} }
         )
 
         res.data


### PR DESCRIPTION
Fixes issue `3f5d0a6da5c7a9bc1c3785402344f451`.

Changes: +1/-1 lines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line change to request parameter construction; main risk is slightly changing behavior for callers that previously passed `0` expecting it to be omitted.
> 
> **Overview**
> Ensures `postOpenRouterMessage` includes the `errorRate` query param whenever it is explicitly provided (including `0`) by switching the check from a truthy test to `errorRate != null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf5d31f62306ce6f2f9a05671ebb3a34257fa83d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->