### PR TITLE
fix: Incoming request failed

### DIFF
--- a/services/timegate/src/services/epoch-engine.service.ts
+++ b/services/timegate/src/services/epoch-engine.service.ts
@@ -21,7 +21,7 @@ export const fetchEpochs = async (
 ): Promise<HistoricalDate[]> => {
     try {
         const { data: epochs } = await axios.get(
-            `${EPOCH_ENGINE_SERVICE_URL}/v1/epoch-engine/epoch`,
+            `${EPOCH_ENGINE_SERVICE_URL}/epoch`,
             { ...errorRate ? { params: { errorRate } } : {} }
         )
 


### PR DESCRIPTION
Fixes issue `f0ec70c783906dd2a537627662625e6a`.

Changes: +1/-1 lines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-complexity change, but it alters the outbound Epoch Engine URL; if the target service routing/versioning differs, the `fetchEpochs` call (and `list-epoch` route) may start failing at runtime.
> 
> **Overview**
> Fixes the Epoch Engine integration by changing `fetchEpochs` to call `${EPOCH_ENGINE_SERVICE_URL}/epoch` instead of the previous versioned path, aligning Timegate’s outbound request URL with the expected endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f9e35e5b3d09400f9c5d9b22d379842a49aa987. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->